### PR TITLE
Add basic unit tests for service layer

### DIFF
--- a/tests/Services/MobileServiceTest.php
+++ b/tests/Services/MobileServiceTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Tests\Services;
+
+use App\Services\MobileService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+class MobileServiceTest extends TestCase
+{
+    private MobileService $mobileService;
+
+    protected function setUp(): void
+    {
+        $this->mobileService = new MobileService();
+    }
+
+    public function testIsMobileReturnsTrueForMobileUserAgent(): void
+    {
+        $request = new Request([], [], [], [], [], ['HTTP_USER_AGENT' => 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_2 like Mac OS X)']);
+        self::assertTrue($this->mobileService->isMobile($request));
+    }
+
+    public function testIsMobileReturnsFalseForDesktopUserAgent(): void
+    {
+        $request = new Request([], [], [], [], [], ['HTTP_USER_AGENT' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)']);
+        self::assertFalse($this->mobileService->isMobile($request));
+    }
+}

--- a/tests/Services/StatusServiceTest.php
+++ b/tests/Services/StatusServiceTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Tests\Services;
+
+use App\Entity\Hangout;
+use App\Entity\Status;
+use App\Repository\StatusRepository;
+use App\Services\StatusService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class StatusServiceTest extends TestCase
+{
+    private EntityManagerInterface $entityManager;
+    private StatusRepository $statusRepository;
+    private StatusService $statusService;
+
+    protected function setUp(): void
+    {
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->statusRepository = $this->createMock(StatusRepository::class);
+        $this->statusService = new StatusService($this->entityManager, $this->statusRepository);
+    }
+
+    public function testCreeHangoutIsRemovedWhenDateBeforeTomorrow(): void
+    {
+        $statusCree = (new Status())->setLabel('Crée');
+        $hangout = (new Hangout())
+            ->setStatus($statusCree)
+            ->setStartingDate(new \DateTimeImmutable('+1 hour'))
+            ->setRegistrationDeadline(new \DateTimeImmutable('-1 day'))
+            ->setDuration(60);
+
+        $this->statusRepository->method('findOneBy')->willReturn(new Status());
+
+        $this->entityManager->expects($this->once())->method('remove')->with($hangout);
+        $this->entityManager->expects($this->never())->method('persist');
+        $this->entityManager->expects($this->once())->method('flush');
+
+        $this->statusService->statusSort([$hangout]);
+    }
+
+    public function testRegistrationDeadlinePassedSetsStatusFermee(): void
+    {
+        $statusOuverte = (new Status())->setLabel('Ouverte');
+        $statusFermee = (new Status())->setLabel('Fermée');
+        $statusEnCours = (new Status())->setLabel('En cours');
+        $statusPassee = (new Status())->setLabel('Passée');
+        $statusArchivee = (new Status())->setLabel('Archivée');
+
+        $this->statusRepository->method('findOneBy')->willReturnMap([
+            [['label' => 'Fermée'], null, $statusFermee],
+            [['label' => 'En cours'], null, $statusEnCours],
+            [['label' => 'Passée'], null, $statusPassee],
+            [['label' => 'Archivée'], null, $statusArchivee],
+        ]);
+
+        $hangout = (new Hangout())
+            ->setStatus($statusOuverte)
+            ->setStartingDate(new \DateTimeImmutable('+2 days'))
+            ->setRegistrationDeadline(new \DateTimeImmutable('-1 day'))
+            ->setDuration(60);
+
+        $this->entityManager->expects($this->once())->method('persist')->with($hangout);
+        $this->entityManager->expects($this->once())->method('flush');
+
+        $this->statusService->statusSort([$hangout]);
+
+        $this->assertSame('Fermée', $hangout->getStatus()->getLabel());
+    }
+}


### PR DESCRIPTION
## Summary
- add a test for `MobileService` to verify detection of mobile vs desktop user agents
- add a test for `StatusService` covering hangout removal and status transition to "Fermée"

## Testing
- `phpunit` *(fails: ./vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688280c9c5bc8331a2408c6b701749a8